### PR TITLE
Patching arithchk.c

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -7,6 +7,10 @@ cd libf2c
 mv ../libf2c.zip .
 unzip libf2c.zip
 
+# Patch arithchk.c to make it compatible with the Fermi Science Tools
+# (and most probably with most other software)
+patch arithchk.c ${RECIPE_DIR}/patch_arithchk
+
 # Using the makefile provided with the package
 # but adding the -fPIC option to the CFLAGS
 sed 's/CFLAGS = -O/CFLAGS = -O -fPIC/g' makefile.u > Makefile

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "f2c" %}
-{% set version = "20160102" %}
+{% set version = "20160103" %}
 {% set sha256 = "fc287517edc67c184bf91860aaa7b342c6c8ce008b298c2a08c4616133009c21" %}
 
 package:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "f2c" %}
-{% set version = "20160101" %}
-{% set sha256 = "5e4e684faccda6bf15b8282766c7c9a21498498b1769652151bee151c9b212da" %}
+{% set version = "20160102" %}
+{% set sha256 = "fc287517edc67c184bf91860aaa7b342c6c8ce008b298c2a08c4616133009c21" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +8,7 @@ package:
 
 source:
   fn: {{ name }}-{{ version }}.tar
-  url: https://github.com/jasercion/fermi-f2c/archive/{{ version }}.tar.gz
+  url: http://netlib.sandia.gov/cgi-bin/netlib/netlibfiles.tar?filename=netlib/{{name}}
   sha256: {{ sha256 }}
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 0
   skip: True  # [vc<14 and win]
 
 requirements:

--- a/recipe/patch_arithchk
+++ b/recipe/patch_arithchk
@@ -1,0 +1,27 @@
+28d27
+< #include <string.h>	/* possibly for ssize_t */
+31d29
+< #include <sys/types.h>	/* another possible place for ssize_t */
+190d187
+< 	size_t sa, sb;
+222,224d218
+< 		if (sizeof(long long) > sizeof(long)
+< 		 && sizeof(long long) == sizeof(void*))
+< 			fprintf(f, "#define LONG_LONG_POINTERS\n");
+228,243d221
+< #ifdef NO_SSIZE_T /*{{*/
+< 		if (sizeof(size_t) == sizeof(long))
+< 			fprintf(f, "#define ssize_t long\n");
+< 		else if (sizeof(size_t) == sizeof(int))
+< 			fprintf(f, "#define ssize_t int\n");
+< #ifndef NO_LONG_LONG
+< 		else if (sizeof(size_t) == sizeof(long long))
+< 			fprintf(f, "#define ssize_t long long\n");
+< #endif
+< 		else
+< 			fprintf(f, "#define ssize_t signed size_t\n"); /* punt */
+< #else /*}{*/
+< 		if (sizeof(size_t) != sizeof(ssize_t))
+< 			fprintf(f, "/* sizeof(size_t) = %d but sizeof(ssize_t) = %d */\n",
+< 				(int)sizeof(size_t), (int)sizeof(ssize_t));
+< #endif /*}}*/


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a fork of the feedstock to propose changes
* [X] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [X] Ensured the license file is being packaged.

Patching arithchk.c so that it doesn't crash when used with the Fermi Science Tools. This fix however most probably affects all other software as well.

<!--
Please add any other relevant info below:
-->
